### PR TITLE
Fix reset icon on Safari

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,4 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated .prettierignore to ignore Github files.
 
+### Fixed
+
+- Missing reset icon in Safari browser (#4).
+
 ## [1.0.0] - 2024-10-28

--- a/src/components/Controls.svelte
+++ b/src/components/Controls.svelte
@@ -127,6 +127,8 @@ A component that holds various control buttons as well as the game timer.
 			stroke="var(--color-text)"
 			stroke-linecap="round"
 			xmlns="http://www.w3.org/2000/svg"
+			height="100%"
+			width="100%"
 		>
 			<path
 				d="


### PR DESCRIPTION
### Fixed
- Missing reset icon in Safari browser (#4).