### PR TITLE
Fix text outlines on stats page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Outlines of "Games Won" values on stats page applied in wrong order on some devices.
 - First "Heart" daily puzzle renamed "Favorite" so that both "Heart" puzzles appear in freeplay.
 
 ## [1.2.0] - 2024-11-25

--- a/src/components/Stats.svelte
+++ b/src/components/Stats.svelte
@@ -468,7 +468,8 @@ A component that presents users with game stats.
 		font-weight: 700;
 		border-radius: 8px;
 		/* this will hopefully keep the data legible regardless of theme colors */
-		-webkit-text-stroke: 0.5px var(--color-text-outline);
+		paint-order: stroke fill;
+		-webkit-text-stroke: 1px var(--color-text-outline);
 	}
 
 	.stats-buttons {


### PR DESCRIPTION
### Fixed

- Outlines of "Games Won" values on stats page applied in wrong order on some devices.